### PR TITLE
Instantiate Recipe objects in the constructor and update tests

### DIFF
--- a/src/classes/RecipeRepository.js
+++ b/src/classes/RecipeRepository.js
@@ -1,13 +1,15 @@
+import Recipe from "./Recipe";
+
 class RecipeRepository {
   constructor(recipeData) {
-    this.recipeData = recipeData;
+    this.recipes = recipeData.map(recipe => new Recipe(recipe));
     this.filteredRecipes;
   }
   filterByTag(tag) {
     if (!tag) {
-      return
+      return;
     }
-    this.filteredRecipes = this.recipeData.filter(recipe => recipe.tags.includes(tag));
+    this.filteredRecipes = this.recipes.filter(recipe => recipe.tags.includes(tag));
 
     if (this.filteredRecipes.length === 0) {
       this.filteredRecipes = null;
@@ -16,9 +18,9 @@ class RecipeRepository {
   }
   filterByName(name) {
     if (!name) {
-      return
+      return;
     }
-    this.filteredRecipes = this.recipeData.filter(recipe => (recipe.name.toUpperCase().includes(name.toUpperCase())));
+    this.filteredRecipes = this.recipes.filter(recipe => (recipe.name.toUpperCase().includes(name.toUpperCase())));
 
     if (this.filteredRecipes.length === 0) {
       this.filteredRecipes = null;

--- a/test/RecipeRepository-test.js
+++ b/test/RecipeRepository-test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import Recipe from '../src/classes/Recipe';
 import RecipeRepository from '../src/classes/RecipeRepository';
 import sampleRecipeData from '../src/data/sample-recipe-data';
 
@@ -18,8 +19,9 @@ describe('RecipeRepository', () => {
     expect(recipe).to.be.an.instanceOf(RecipeRepository);
   });
 
-  it('should have a recipe data property', () => {
-    expect(recipe.recipeData).to.have.lengthOf(3);
+  it('should have a recipes data property', () => {
+    expect(recipe.recipes).to.have.lengthOf(3);
+    expect(recipe.recipes[0]).to.be.an.instanceOf(Recipe);
   });
 
   it('should start with no filtered recipes', () => {


### PR DESCRIPTION
I updated the RecipeRepository to instantiate Recipe objects within the constructor to more closely follow the spec. This seems helpful for populating the data onto the DOM directly from the DM